### PR TITLE
.github/workflows/build-debian.yml: Added a GitHub action that upload…

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -22,3 +22,10 @@ jobs:
     - name: build
       run: |
            debuild --no-lintian --no-sign
+    - name: Upload Test Build Artifact
+      if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name != 'master' && github.ref_name != 'development' }}
+      uses: actions/upload-artifact@v2
+      with:
+        retention-days: 5
+        name: packetsender-testbuild-${{ github.ref_name }}
+        path: obj-x86_64-linux-gnu/PacketSender


### PR DESCRIPTION
.github/workflows/build-debian.yml: Added a GitHub action that uploads the built version of the binary as an artifact of the workflow for pushes on branches (but not tags) that are not "master" or "development". The artifact is retained for 5 days to conserve space.

Can be downloaded from the summary page for a workflow that matches the parameters described above.
